### PR TITLE
Fix broken CODE_OF_CONDUCT and LICENSE links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,13 @@
 [fork]: https://github.com/github/forgoodfirstissue/fork
 [pr]: https://github.com/github/forgoodfirstissue/compare
 [style]: https://github.com/github/forgoodfirstissue/blob/main/.eslintrc.json
-[code-of-conduct]: CODE_OF_CONDUCT.md
+[code-of-conduct]: https://github.com/github/.github/blob/main/CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 
-Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.md).
+Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
 
-Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](https://github.com/github/.github/blob/main/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
 ## Submitting a pull request
 


### PR DESCRIPTION
### Description

- Updates the `CONTRIBUTING.md` file to correct broken links for `CODE_OF_CONDUCT.md` and `LICENSE.md`.
- Changes references to proper paths:
  - `[Contributor Code of Conduct](https://github.com/github/.github/blob/main/CODE_OF_CONDUCT.md)`
  - `[Project License](LICENSE)`

### Related issue
Closes #362.

