### PR TITLE
Remove duplicate repositories from happycommits data and fixed invalid repo format

### DIFF
--- a/happycommits.json
+++ b/happycommits.json
@@ -166,7 +166,6 @@
     "openimis/openimis-dist_dkr",
     "openmrs/openmrs-core",
     "openmrs/openmrs-contrib-android-client",
-    "opencrvs/opencrvs-core",
     "openkfw/TruBudget",
     "OpenSPP/openspp-modules",
     "openspp-project/openspp-registry",
@@ -199,7 +198,7 @@
     "reconverse/outbreaks",
     "reconverse/reportfactory",
     "reconverse/trending",
-    "reconverse/trendeval/",
+    "reconverse/trendeval",
     "rubyforgood/casa",
     "rubyforgood/human-essentials",
     "rubyforgood/pet-rescue",
@@ -245,8 +244,7 @@
     "vrapeutic/Rodja-webXR",
     "WFP-VAM/prism-app",
     "WorldHealthOrganization/godata",
-    "Zenysis/Harmony",
-    "datakind/Data-Observation-Toolkit"
+    "Zenysis/Harmony"
   ],
   "labels": [
     "good first issue",


### PR DESCRIPTION
Fixes #449 

This PR removes duplicate repository entries from the data list and ensures
each repository appears only once.

#### Duplicates removed
- datakind/Data-Observation-Toolkit
- opencrvs/opencrvs-core
