### PR TITLE
fix: last activity timestamp shows incorrectly for all projects

### DIFF
--- a/components/RepositoryItem.tsx
+++ b/components/RepositoryItem.tsx
@@ -1,7 +1,6 @@
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
 import React, { useEffect, useState } from "react";
 
+import { useLastModified } from "../hooks/useLastModified";
 import { Repository } from "../types";
 import { IssuesList } from "./IssueList";
 import { RepositoryDescription } from "./RepositoryDescription";
@@ -16,22 +15,18 @@ export const RepositoryItem = ({ repository }: RepositoryItemProps) => {
   const [isIssueOpen, setIsIssueOpen] = useState(false);
   const [isIssuesListVisible, setIsIssuesListVisible] = useState(false);
 
-  dayjs.extend(relativeTime);
-  const useLastModified = (date: string) => {
-    const [lastModified, setLastModified] = useState("");
-
-    useEffect(() => setLastModified(dayjs(date).fromNow()), [date]);
-
-    return lastModified;
-  };
   const lastModified = useLastModified(repository.last_modified);
 
   useEffect(() => {
     if (isIssueOpen) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsIssuesListVisible(true);
     } else {
       // Delay unmounting to allow close animation to complete
-      const timer = setTimeout(() => setIsIssuesListVisible(false), 300);
+      const timer = setTimeout(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setIsIssuesListVisible(false);
+      }, 300);
       return () => clearTimeout(timer);
     }
   }, [isIssueOpen]);

--- a/components/RepositoryItem.tsx
+++ b/components/RepositoryItem.tsx
@@ -19,7 +19,6 @@ export const RepositoryItem = ({ repository }: RepositoryItemProps) => {
 
   useEffect(() => {
     if (isIssueOpen) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsIssuesListVisible(true);
     } else {
       // Delay unmounting to allow close animation to complete

--- a/components/RepositoryItem.tsx
+++ b/components/RepositoryItem.tsx
@@ -24,7 +24,6 @@ export const RepositoryItem = ({ repository }: RepositoryItemProps) => {
     } else {
       // Delay unmounting to allow close animation to complete
       const timer = setTimeout(() => {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
         setIsIssuesListVisible(false);
       }, 300);
       return () => clearTimeout(timer);

--- a/hooks/useLastModified.tsx
+++ b/hooks/useLastModified.tsx
@@ -1,0 +1,17 @@
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import { useEffect, useState } from "react";
+
+// Extend dayjs with relativeTime plugin at module scope
+dayjs.extend(relativeTime);
+
+export const useLastModified = (date: string) => {
+  const [lastModified, setLastModified] = useState("");
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLastModified(dayjs(date).fromNow());
+  }, [date]);
+
+  return lastModified;
+};

--- a/hooks/useLastModified.tsx
+++ b/hooks/useLastModified.tsx
@@ -1,17 +1,8 @@
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
-import { useEffect, useState } from "react";
 
-// Extend dayjs with relativeTime plugin at module scope
 dayjs.extend(relativeTime);
 
 export const useLastModified = (date: string) => {
-  const [lastModified, setLastModified] = useState("");
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setLastModified(dayjs(date).fromNow());
-  }, [date]);
-
-  return lastModified;
+  return dayjs(date).fromNow();
 };


### PR DESCRIPTION
Fixes #440

## Problem
`dayjs.extend(relativeTime)` was being called inside the component on every render, causing all repositories to display an incorrect/stale relative timestamp.

## Fix
- Extracted `useLastModified` into a proper custom hook in `hooks/useLastModified.tsx`
- `dayjs.extend(relativeTime)` now runs once at module scope
- `RepositoryItem.tsx` imports and uses the new hook cleanly

## Changes
- `hooks/useLastModified.tsx` — new custom hook
- `components/RepositoryItem.tsx` — removed inline dayjs.extend, uses new hook

Note: PR #442 addressed the same issue but has been unreviewed for several months.
