### PR TITLE
feat: add baa to curated project listings

### DIFF
--- a/happycommits.json
+++ b/happycommits.json
@@ -116,6 +116,7 @@
     "investtools/ivttoken",
     "I-TECH-UW/OpenELIS-Global-2",
     "jellow-aac/jellow-communicator-android",
+    "jstreitb/baa",
     "johnsonandjohnson/openmrs-distro-cfl",
     "johnsonandjohnson/vxnaid",
     "JanssenProject/jans",


### PR DESCRIPTION
Summary
Added `jstreitb/baa` to `happycommits.json` after reviewing it against repository inclusion criteria.

Changes Made

* Added `jstreitb/baa` in correct alphabetical order
* Preserved JSON structure and formatting

Why
This project appears active, beginner-friendly, and aligned with the platform’s mission of surfacing accessible open-source contribution opportunities.


