### PR TITLE
Remove duplicate repository entries

### DIFF
--- a/generate.ts
+++ b/generate.ts
@@ -95,6 +95,14 @@ slugify.extend({
   "+": "plus"
 });
 
+const uniqueByRepositoryKey = (repositories: RepositoryModel[]) =>
+  Array.from(
+    repositories.reduce((map, repository) => {
+      map.set(`${repository.owner}/${repository.name}`, repository);
+      return map;
+    }, new Map<string, RepositoryModel>()).values()
+  );
+
 // Setup Octokit (GitHub API client)
 const MyOctokit = Octokit.plugin(throttling, retry);
 const octokit = new MyOctokit({
@@ -453,7 +461,7 @@ const getRepositories = async (
       .sort((a, b) => b.count - a.count);
 
     return {
-      repositories: repoData.sort(() => Math.random() - 0.5),
+      repositories: uniqueByRepositoryKey(repoData).sort(() => Math.random() - 0.5),
       languages: filterLanguages,
       topics: filterTopics
     };

--- a/happycommits.json
+++ b/happycommits.json
@@ -166,7 +166,6 @@
     "openimis/openimis-dist_dkr",
     "openmrs/openmrs-core",
     "openmrs/openmrs-contrib-android-client",
-    "opencrvs/opencrvs-core",
     "openkfw/TruBudget",
     "OpenSPP/openspp-modules",
     "openspp-project/openspp-registry",
@@ -244,8 +243,7 @@
     "vrapeutic/Rodja-webXR",
     "WFP-VAM/prism-app",
     "WorldHealthOrganization/godata",
-    "Zenysis/Harmony",
-    "datakind/Data-Observation-Toolkit"
+    "Zenysis/Harmony"
   ],
   "labels": [
     "good first issue",


### PR DESCRIPTION
Removes duplicated repository entries from the source dataset and adds a guard in the generator to prevent repeated repositories from leaking into generated output.