### PR TITLE
Add Toxin Scout Enviro Map Kit

### DIFF
--- a/happycommits.json
+++ b/happycommits.json
@@ -130,6 +130,7 @@
     "learningequality/kolibri-design-system",
     "learningequality/ricecooker",
     "learningequality/studio",
+    "mattd3080/toxin-scout-enviro-map-kit",
     "mautic/mautic",
     "medic/cht-core",
     "Medtronic-LABS/spice-android",


### PR DESCRIPTION
Adds mattd3080/toxin-scout-enviro-map-kit to happycommits.json.\n\nIssues page: https://github.com/mattd3080/toxin-scout-enviro-map-kit/issues\n\nThe repo is a public MIT-licensed civic/environmental health map component with a README, CONTRIBUTING.md, and four open issues labeled `good first issue` and `help wanted`. The repository description and topics include SDG 3, SDG 11, and SDG 16 framing.