### PR TITLE
Add TEAM_REQUESTS_TOKEN to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,7 @@ jobs:
         run: npm run build
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          TEAM_REQUESTS_TOKEN: ${{ secrets.TEAM_REQUESTS_TOKEN }}
       - name: Update happycommits.json
         uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a #v4.16.0
         with:


### PR DESCRIPTION
Missed adding this to the GitHub action. Will enable the team requests to be pulled in.